### PR TITLE
CPD図でtargetの元素の種類とelementsの元素の種類が違うときの動作を追加

### DIFF
--- a/pydefect/chem_pot_diag/chem_pot_diag.py
+++ b/pydefect/chem_pot_diag/chem_pot_diag.py
@@ -407,7 +407,21 @@ def change_element_sequence(cpd: ChemPotDiag,
                              f"Input elements {element_sequence}")
     else:
         if cpd.target:
-            element_sequence = [str(e) for e in Composition(cpd.target).elements]
+            target_element_sequence = [str(e) for e in Composition(cpd.target).elements]
+            if set(cpd.vertex_elements) == set(target_element_sequence):
+                element_sequence = cpd.vertex_elements
+            elif set(cpd.vertex_elements) > set(target_element_sequence):
+                element_sequence = cpd.vertex_elements
+                logger.warning(f"CPD elements are "
+                               f"superset of Original elements {target_element_sequence}.")
+            elif set(target_element_sequence) > set(cpd.vertex_elements):
+                element_sequence = target_element_sequence
+                logger.warning(f"CPD elements are "
+                               f"subset of Target Composite elements {target_element_sequence}.")
+            else:
+                raise ValueError(f"Original elements {cpd.vertex_elements}. "
+                                 f"Target Composite elements {target_element_sequence}. "
+                                 f"Target Composite elements must be subset of Original elements.")
         else:
             return result
 


### PR DESCRIPTION
## 問題
```bash
pydefect cv -t Ga2O3 -e Ga O Si
```
↓
```bash
pydefect pc
```
を行った際に2元系の化学ポテンシャル図が描画される。

## 想定される挙動
3元系の化学ポテンシャル図が描画される。

## 問題点
`pydefect pc`が実行の際に、`chem_pot_diag.json`で`target (pydefect cv -t)`が指定されていると、`elements (pydefect cv -e)`が考慮されていない。

## 修正
考慮するように変更。