### PR TITLE
Pydefect Faster Step1: Lazy Import

### DIFF
--- a/pydefect/cli/main.py
+++ b/pydefect/cli/main.py
@@ -6,24 +6,39 @@ import sys
 import warnings
 from pathlib import Path
 
-from monty.serialization import loadfn
 from pydefect import __version__
-from pydefect.analyzer.unitcell import Unitcell
-from pydefect.chem_pot_diag.chem_pot_diag import StandardEnergies
-from pydefect.cli.main_functions import plot_defect_energy, \
-    make_standard_and_relative_energies, make_cpd_and_vertices, \
-    plot_chem_pot_diag, make_supercell, append_interstitial_to_supercell_info, \
-    pop_interstitial_from_supercell_info, make_defect_set, \
-    make_efnv_correction_main_func, make_band_edge_states_main_func, \
-    make_defect_energy_infos_main_func, make_defect_energy_summary_main_func, \
-    calc_defect_structure_info, make_calc_summary_main_func
-from pydefect.cli.main_tools import str_int_to_int
 from pydefect.defaults import defaults
-from pymatgen.core import IStructure, Structure
-from pymatgen.io.vasp.inputs import UnknownPotcarWarning
 
-warnings.simplefilter('ignore', UnknownPotcarWarning)
+def lazy_load_unitcell(path):
+    from pydefect.analyzer.unitcell import Unitcell
+    return Unitcell.from_yaml(path)
 
+def lazy_load_json(path):
+    from monty.serialization import loadfn
+    return loadfn(path)
+
+def lazy_load_structure(path):
+    from pymatgen.core import IStructure, Structure
+    return IStructure.from_file(path)
+
+def lazy_load_structure_mutable(path):
+    from pymatgen.core import Structure
+    return Structure.from_file(path)
+
+def lazy_load_standard_energies(path):
+    from pydefect.chem_pot_diag.chem_pot_diag import StandardEnergies
+    return StandardEnergies.from_yaml(path)
+
+def lazy_str_int_to_int(value):
+    from pydefect.cli.main_tools import str_int_to_int
+    return str_int_to_int(value)
+
+def setup_warnings():
+    try:
+        from pymatgen.io.vasp.inputs import UnknownPotcarWarning
+        warnings.simplefilter('ignore', UnknownPotcarWarning)
+    except ImportError:
+        pass
 
 description = """pydefect is a package that helps researchers to 
 do first-principles point defect calculations with the VASP code."""
@@ -43,34 +58,34 @@ def add_sub_parser(_argparse, name: str):
             help="Directory paths to be parsed.")
     elif name == "unitcell":
         result.add_argument(
-            "-u", "--unitcell", type=Unitcell.from_yaml, required=True,
+            "-u", "--unitcell", type=lazy_load_unitcell, required=True,
             help="Path to the unitcell.yaml file.")
     elif name == "supercell_info":
         result.add_argument(
-            "-s", "--supercell_info", type=loadfn,
+            "-s", "--supercell_info", type=lazy_load_json,
             default="supercell_info.json",
             help="Path to the supercell_info.json file.")
     elif name == "perfect_calc_results":
         result.add_argument(
-            "-pcr", "--perfect_calc_results", required=True, type=loadfn,
+            "-pcr", "--perfect_calc_results", required=True, type=lazy_load_json,
             help="Path to the calc_results.json for the perfect supercell.")
     elif name == "perfect_band_edge_state":
         result.add_argument(
-            "-pbes", "--p_state", required=True, type=loadfn,
+            "-pbes", "--p_state", required=True, type=lazy_load_json,
             help="Path to the perfect_band_edge_state.json.")
     elif name == "no_calc_results_check":
         result.add_argument(
             "-nccr", "--no_calc_results_check",
-            action="store_false",  dest="check_calc_results",
+            action="store_false", dest="check_calc_results",
             help="Select this option when not checking calc_results.json.")
     elif name == "verbose":
         result.add_argument(
             "-v", "--verbose",
-            action="store_true",  dest="verbose",
+            action="store_true", dest="verbose",
             help="Select if one wants to show traceback.")
     elif name == "defect_energy_summary":
         result.add_argument(
-            "-d", "--defect_energy_summary", required=True, type=loadfn,
+            "-d", "--defect_energy_summary", required=True, type=lazy_load_json,
             help="defect_energy_summary.json file path.")
         result.add_argument(
             "--allow_shallow", action="store_true",
@@ -85,6 +100,75 @@ def add_sub_parser(_argparse, name: str):
         raise ValueError
     return result
 
+def wrapped_make_standard_and_relative_energies(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_standard_and_relative_energies
+    return make_standard_and_relative_energies(args)
+
+def wrapped_make_cpd_and_vertices(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_cpd_and_vertices
+    return make_cpd_and_vertices(args)
+
+def wrapped_plot_chem_pot_diag(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import plot_chem_pot_diag
+    return plot_chem_pot_diag(args)
+
+def wrapped_make_supercell(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_supercell
+    return make_supercell(args)
+
+def wrapped_append_interstitial_to_supercell_info(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import append_interstitial_to_supercell_info
+    return append_interstitial_to_supercell_info(args)
+
+def wrapped_pop_interstitial_from_supercell_info(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import pop_interstitial_from_supercell_info
+    return pop_interstitial_from_supercell_info(args)
+
+def wrapped_make_defect_set(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_defect_set
+    return make_defect_set(args)
+
+def wrapped_calc_defect_structure_info(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import calc_defect_structure_info
+    return calc_defect_structure_info(args)
+
+def wrapped_make_efnv_correction_main_func(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_efnv_correction_main_func
+    return make_efnv_correction_main_func(args)
+
+def wrapped_make_band_edge_states_main_func(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_band_edge_states_main_func
+    return make_band_edge_states_main_func(args)
+
+def wrapped_make_defect_energy_infos_main_func(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_defect_energy_infos_main_func
+    return make_defect_energy_infos_main_func(args)
+
+def wrapped_make_defect_energy_summary_main_func(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_defect_energy_summary_main_func
+    return make_defect_energy_summary_main_func(args)
+
+def wrapped_make_calc_summary_main_func(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import make_calc_summary_main_func
+    return make_calc_summary_main_func(args)
+
+def wrapped_plot_defect_energy(args):
+    setup_warnings()
+    from pydefect.cli.main_functions import plot_defect_energy
+    return plot_defect_energy(args)
 
 dirs_parsers = [add_sub_parser(argparse, name="dirs"),
                 add_sub_parser(argparse, name="verbose")]
@@ -114,7 +198,7 @@ def parse_args_main(args):
         default="composition_energies.yaml",
         help="composition_energies.yaml file name.")
     parser_make_standard_and_relative_energies.set_defaults(
-        func=make_standard_and_relative_energies)
+        func=wrapped_make_standard_and_relative_energies)
 
     # -- make_cpd_and_vertices -------------------------------------------------
     parser_cv = subparsers.add_parser(
@@ -134,7 +218,7 @@ def parse_args_main(args):
         "-e", "--elements", type=str, nargs="+",
         help="Element names considered in chemical potential diagram. Used for "
              "creating the diagram.")
-    parser_cv.set_defaults(func=make_cpd_and_vertices)
+    parser_cv.set_defaults(func=wrapped_make_cpd_and_vertices)
 
     # -- plot_cpd ------------------------------------------------
     parser_pcpd = subparsers.add_parser(
@@ -143,9 +227,9 @@ def parse_args_main(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['pc'])
     parser_pcpd.add_argument(
-        "-cpd", "--chem_pot_diag", default="chem_pot_diag.json", type=loadfn,
+        "-cpd", "--chem_pot_diag", default="chem_pot_diag.json", type=lazy_load_json,
         help="Path to the chem_pot_diag.json file.")
-    parser_pcpd.set_defaults(func=plot_chem_pot_diag)
+    parser_pcpd.set_defaults(func=wrapped_plot_chem_pot_diag)
 
     # -- supercell ------------------------------------------------
     parser_supercell = subparsers.add_parser(
@@ -155,7 +239,7 @@ def parse_args_main(args):
         aliases=['s'])
 
     parser_supercell.add_argument(
-        "-p", "--unitcell", type=IStructure.from_file, required=True,
+        "-p", "--unitcell", type=lazy_load_structure, required=True,
         help="Base structure file, which must be the standardized primitive "
              "cell.")
     parser_supercell.add_argument(
@@ -185,7 +269,7 @@ O1:
 Here site_index is based on the given structure.
 """)
 
-    parser_supercell.set_defaults(func=make_supercell)
+    parser_supercell.set_defaults(func=wrapped_make_supercell)
 
     # -- append_interstitial ------------------------------------------------
     parser_append_interstitial = subparsers.add_parser(
@@ -196,7 +280,7 @@ Here site_index is based on the given structure.
         aliases=['ai'])
 
     parser_append_interstitial.add_argument(
-        "-p", "--base_structure", required=True, type=Structure.from_file,
+        "-p", "--base_structure", required=True, type=lazy_load_structure_mutable,
         help="Structure file defining the fractional coordinates such as the "
              "standardized primitive cell.")
     parser_append_interstitial.add_argument(
@@ -208,7 +292,7 @@ Here site_index is based on the given structure.
         help="Information related to the appended interstitial site if exists.")
 
     parser_append_interstitial.set_defaults(
-        func=append_interstitial_to_supercell_info)
+        func=wrapped_append_interstitial_to_supercell_info)
 
     # -- pop_interstitial ------------------------------------------------
     parser_pop_interstitial = subparsers.add_parser(
@@ -226,7 +310,7 @@ Here site_index is based on the given structure.
         help="Pop all interstitials. If this is set, index option is ignored.")
 
     parser_pop_interstitial.set_defaults(
-        func=pop_interstitial_from_supercell_info)
+        func=wrapped_pop_interstitial_from_supercell_info)
 
     # -- defect_set ------------------------------------------------
     parser_defect_set = subparsers.add_parser(
@@ -236,7 +320,7 @@ Here site_index is based on the given structure.
         aliases=['ds'])
 
     parser_defect_set.add_argument(
-        "-o", "--oxi_states", nargs="+", type=str_int_to_int,
+        "-o", "--oxi_states", nargs="+", type=lazy_str_int_to_int,
         help="Oxidation states in integers, e.g., Mg 2 O -2.")
     parser_defect_set.add_argument(
         "-d", "--dopants", nargs="+", type=str,
@@ -246,7 +330,7 @@ Here site_index is based on the given structure.
         help="Keywords used to screen the target defects. Since, the re.search "
              "is used inside, Regular expression can be used. ")
 
-    parser_defect_set.set_defaults(func=make_defect_set)
+    parser_defect_set.set_defaults(func=wrapped_make_defect_set)
 
     # -- defect structure info ------------------------------------------------
     parser_defect_structure_info = subparsers.add_parser(
@@ -265,7 +349,7 @@ Here site_index is based on the given structure.
         help="Tolerance for determining point groups in the final "
              "structures. Note that point groups in the initial structures are "
              "set via defect_entry.json files.")
-    parser_defect_structure_info.set_defaults(func=calc_defect_structure_info)
+    parser_defect_structure_info.set_defaults(func=wrapped_calc_defect_structure_info)
 
     # -- efnv correction ------------------------------------------------
     parser_efnv = subparsers.add_parser(
@@ -283,7 +367,7 @@ Here site_index is based on the given structure.
     parser_efnv.add_argument(
         "--calc_all_sites", action="store_true",
         help="Set if one wants to calculate the potential at all the sites.")
-    parser_efnv.set_defaults(func=make_efnv_correction_main_func)
+    parser_efnv.set_defaults(func=wrapped_make_efnv_correction_main_func)
 
     # -- band edge states ------------------------------------------------
     parser_band_edge_states = subparsers.add_parser(
@@ -293,7 +377,7 @@ Here site_index is based on the given structure.
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['bes'])
 
-    parser_band_edge_states.set_defaults(func=make_band_edge_states_main_func)
+    parser_band_edge_states.set_defaults(func=wrapped_make_band_edge_states_main_func)
 
     # -- defect energy infos ---------------------------------------------------
     parser_defect_energy_infos = subparsers.add_parser(
@@ -303,11 +387,11 @@ Here site_index is based on the given structure.
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['dei'])
     parser_defect_energy_infos.add_argument(
-        "-s", "--std_energies", required=True, type=StandardEnergies.from_yaml,
+        "-s", "--std_energies", required=True, type=lazy_load_standard_energies,
         help="Path to the StandardEnergies.yaml file.")
 
     parser_defect_energy_infos.set_defaults(
-        func=make_defect_energy_infos_main_func)
+        func=wrapped_make_defect_energy_infos_main_func)
 
     # -- defect energy summary -------------------------------------------------
     parser_defect_energy_summary = subparsers.add_parser(
@@ -321,7 +405,7 @@ Here site_index is based on the given structure.
         help="Path to the target_vertices.yaml file.")
 
     parser_defect_energy_summary.set_defaults(
-        func=make_defect_energy_summary_main_func)
+        func=wrapped_make_defect_energy_summary_main_func)
 
     # -- calc summary -------------------------------------------------
     parser_calc_summary = subparsers.add_parser(
@@ -332,7 +416,7 @@ Here site_index is based on the given structure.
         aliases=['cs'])
 
     parser_calc_summary.set_defaults(
-        func=make_calc_summary_main_func)
+        func=wrapped_make_calc_summary_main_func)
 
     # -- plot defect formation energy ------------------------------------------
     parser_plot_energy = subparsers.add_parser(
@@ -354,7 +438,7 @@ Here site_index is based on the given structure.
     parser_plot_energy.add_argument(
         "--plot_all_energies", dest="plot_all_energies", action="store_true",
         help="Plot energies of all charge states including unstable ones.")
-    parser_plot_energy.set_defaults(func=plot_defect_energy)
+    parser_plot_energy.set_defaults(func=wrapped_plot_defect_energy)
     # ------------------------------------------------------------------------
     return parser.parse_args(args)
 

--- a/pydefect/cli/main_util.py
+++ b/pydefect/cli/main_util.py
@@ -3,20 +3,68 @@
 
 import argparse
 import sys
-import warnings
 
-from monty.serialization import loadfn
-from pydefect.analyzer.concentration.degeneracy import Degeneracies
-from pydefect.cli.main import description, epilog, add_sub_parser, dirs_parsers
-from pydefect.cli.main_util_functions import make_gkfo_correction_from_vasp, \
-    composition_energies_from_mp, add_interstitials_from_local_extrema, \
-    make_defect_vesta_file, show_u_values, show_pinning_levels, \
-    make_degeneracies, calc_defect_concentrations, calc_carrier_concentrations, \
-    plot_carrier_concentrations, plot_defect_concentrations
+from pydefect.cli.main import description, epilog, add_sub_parser, dirs_parsers, setup_warnings, lazy_load_json
 from pydefect.defaults import defaults
-from pymatgen.io.vasp.inputs import UnknownPotcarWarning
 
-warnings.simplefilter('ignore', UnknownPotcarWarning)
+def lazy_load_degeneracies(path):
+    from pydefect.analyzer.concentration.degeneracy import Degeneracies
+    return Degeneracies.from_yaml(path)
+
+def wrapped_make_gkfo_correction_from_vasp(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import make_gkfo_correction_from_vasp
+    return make_gkfo_correction_from_vasp(args)
+
+def wrapped_composition_energies_from_mp(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import composition_energies_from_mp
+    return composition_energies_from_mp(args)
+
+def wrapped_add_interstitials_from_local_extrema(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import add_interstitials_from_local_extrema
+    return add_interstitials_from_local_extrema(args)
+
+def wrapped_make_defect_vesta_file(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import make_defect_vesta_file
+    return make_defect_vesta_file(args)
+
+def wrapped_show_u_values(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import show_u_values
+    return show_u_values(args)
+
+def wrapped_show_pinning_levels(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import show_pinning_levels
+    return show_pinning_levels(args)
+
+def wrapped_make_degeneracies(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import make_degeneracies
+    return make_degeneracies(args)
+
+def wrapped_calc_defect_concentrations(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import calc_defect_concentrations
+    return calc_defect_concentrations(args)
+
+def wrapped_calc_carrier_concentrations(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import calc_carrier_concentrations
+    return calc_carrier_concentrations(args)
+
+def wrapped_plot_carrier_concentrations(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import plot_carrier_concentrations
+    return plot_carrier_concentrations(args)
+
+def wrapped_plot_defect_concentrations(args):
+    setup_warnings()
+    from pydefect.cli.main_util_functions import plot_defect_concentrations
+    return plot_defect_concentrations(args)
 
 
 def parse_args_main_util(args):
@@ -45,7 +93,7 @@ def parse_args_main_util(args):
         "-a", "--atom_energy_yaml", type=str,
         help="Yaml file storing atom energies for energy alignment.")
 
-    parser_comp_es_from_mp.set_defaults(func=composition_energies_from_mp)
+    parser_comp_es_from_mp.set_defaults(func=wrapped_composition_energies_from_mp)
 
     # -- show u values ------------------------------------------
     parser_show_u_values = subparsers.add_parser(
@@ -55,7 +103,7 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['u'])
 
-    parser_show_u_values.set_defaults(func=show_u_values)
+    parser_show_u_values.set_defaults(func=wrapped_show_u_values)
 
     # -- show pinning levels ------------------------------------------
     parser_show_pinning_levels = subparsers.add_parser(
@@ -65,7 +113,7 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['pl'])
 
-    parser_show_pinning_levels.set_defaults(func=show_pinning_levels)
+    parser_show_pinning_levels.set_defaults(func=wrapped_show_pinning_levels)
 
     # -- add interstitials from local extrema ----------------------------------
     parser_ai = subparsers.add_parser(
@@ -76,12 +124,12 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['ai'])
     parser_ai.add_argument(
-        "--local_extrema", required=True, type=loadfn,
+        "--local_extrema", required=True, type=lazy_load_json,
         help="volumetric_data_local_extrema.json file name.")
     parser_ai.add_argument(
         "-i", "--indices", required=True, type=int, nargs="+",
         help="Indices starting from 1 to be added to SupercellInfo.")
-    parser_ai.set_defaults(func=add_interstitials_from_local_extrema)
+    parser_ai.set_defaults(func=wrapped_add_interstitials_from_local_extrema)
 
     # -- make defect vesta file ------------------------------------------------
     parser_dvf = subparsers.add_parser(
@@ -103,7 +151,7 @@ def parse_args_main_util(args):
     parser_dvf.add_argument(
         "--title", type=str, help="Title to be shown in VESTA files.")
 
-    parser_dvf.set_defaults(func=make_defect_vesta_file)
+    parser_dvf.set_defaults(func=wrapped_make_defect_vesta_file)
 
     # -- gkfo correction -------------------------------------------------------
     parser_gkfo = subparsers.add_parser(
@@ -114,19 +162,19 @@ def parse_args_main_util(args):
         aliases=['gkfo'])
 
     parser_gkfo.add_argument(
-        "-iefnv", "--initial_efnv_correction", required=True, type=loadfn,
+        "-iefnv", "--initial_efnv_correction", required=True, type=lazy_load_json,
         help="Path to the initial efnv correction.json file.")
     parser_gkfo.add_argument(
-        "-icr", "--initial_calc_results", required=True, type=loadfn,
+        "-icr", "--initial_calc_results", required=True, type=lazy_load_json,
         help="Path to the initial calc_results.json file.")
     parser_gkfo.add_argument(
-        "-fcr", "--final_calc_results", required=True, type=loadfn,
+        "-fcr", "--final_calc_results", required=True, type=lazy_load_json,
         help="Path to the final calc_results.json file.")
     parser_gkfo.add_argument(
         "-cd", "--charge_diff", required=True, type=int,
         help="Charge difference of final state from initial state.")
 
-    parser_gkfo.set_defaults(func=make_gkfo_correction_from_vasp)
+    parser_gkfo.set_defaults(func=wrapped_make_gkfo_correction_from_vasp)
 
     # -- make degeneracies ---------------------------------------------------
     parser_make_degeneracies = subparsers.add_parser(
@@ -138,7 +186,7 @@ def parse_args_main_util(args):
         aliases=['md'])
 
     parser_make_degeneracies.set_defaults(
-        func=make_degeneracies)
+        func=wrapped_make_degeneracies)
 
     # -- calc carrier concentrations  ------------------------------------------
     parser_calc_carrier_concentrations = subparsers.add_parser(
@@ -148,14 +196,14 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['ccc'])
     parser_calc_carrier_concentrations.add_argument(
-        "-t", "--total_dos", required=True, type=loadfn,
+        "-t", "--total_dos", required=True, type=lazy_load_json,
         help="total_dos.json")
     parser_calc_carrier_concentrations.add_argument(
         "-T", "--T", type=float, default=300,
         help="Temperature in K.")
 
     parser_calc_carrier_concentrations.set_defaults(
-        func=calc_carrier_concentrations)
+        func=wrapped_calc_carrier_concentrations)
 
     # -- calc defect concentrations  -------------------------------------------
     parser_calc_defect_concentrations = subparsers.add_parser(
@@ -165,23 +213,23 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['cdc'])
     parser_calc_defect_concentrations.add_argument(
-        "--degeneracies", required=True, type=Degeneracies.from_yaml,
+        "--degeneracies", required=True, type=lazy_load_degeneracies,
         help="degeneracies.yaml")
     parser_calc_defect_concentrations.add_argument(
-        "-t", "--total_dos", required=True, type=loadfn,
+        "-t", "--total_dos", required=True, type=lazy_load_json,
         help="total_dos.json")
     parser_calc_defect_concentrations.add_argument(
         "-T", "--T", type=float, default=300,
         help="Temperature in K.")
     parser_calc_defect_concentrations.add_argument(
-        "--con_by_Ef", type=loadfn, default=None,
+        "--con_by_Ef", type=lazy_load_json, default=None,
         help="con_by_Ef.json file.")
     parser_calc_defect_concentrations.add_argument(
         "--net_abs_ratio", type=float, default=1e-5,
         help="Ratio to determine the convergence.")
 
     parser_calc_defect_concentrations.set_defaults(
-        func=calc_defect_concentrations)
+        func=wrapped_calc_defect_concentrations)
 
     # -- plot carrier concentrations  ------------------------------------------
     parser_plot_carrier_concentrations = subparsers.add_parser(
@@ -190,7 +238,7 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['pcc'])
     parser_plot_carrier_concentrations.add_argument(
-        "-c", "--con_by_Ef", required=True, type=loadfn, nargs="+",
+        "-c", "--con_by_Ef", required=True, type=lazy_load_json, nargs="+",
         help="con_by_Ef.json file name")
     parser_plot_carrier_concentrations.add_argument(
         "-cr", "--concentration_ranges", type=float, nargs="+",
@@ -200,7 +248,7 @@ def parse_args_main_util(args):
         help="Energy ranges.")
 
     parser_plot_carrier_concentrations.set_defaults(
-        func=plot_carrier_concentrations)
+        func=wrapped_plot_carrier_concentrations)
 
     # -- plot defect concentrations  ------------------------------------------
     parser_plot_defect_concentrations = subparsers.add_parser(
@@ -209,11 +257,11 @@ def parse_args_main_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['pdc'])
     parser_plot_defect_concentrations.add_argument(
-        "-c", "--con_by_Ef", required=True, type=loadfn,
+        "-c", "--con_by_Ef", required=True, type=lazy_load_json,
         help="con_by_Ef.json file name")
 
     parser_plot_defect_concentrations.set_defaults(
-        func=plot_defect_concentrations)
+        func=wrapped_plot_defect_concentrations)
 
     # ------------------------------------------------------------------------
 

--- a/pydefect/cli/vasp/main_vasp_util.py
+++ b/pydefect/cli/vasp/main_vasp_util.py
@@ -6,19 +6,45 @@ import argparse
 import sys
 import warnings
 
-from monty.serialization import loadfn
 from pydefect.analyzer.grids import Grids
-from pydefect.cli.main import epilog, description, add_sub_parser
-from pydefect.cli.vasp.main_vasp_util_functions import \
-    make_parchg_dir, make_refine_defect_poscar, \
-    calc_charge_state, make_defect_entry_main, calc_grids, \
-    make_defect_charge_info_main, make_total_dos
-from pymatgen.core import Structure
-from pymatgen.io.vasp import Chgcar, Vasprun, Outcar
-from pymatgen.io.vasp.inputs import UnknownPotcarWarning
+from pydefect.cli.main import epilog, description, add_sub_parser, setup_warnings, lazy_load_json, lazy_load_structure_mutable
+from pydefect.cli.vasp.main_vasp import lazy_vasprun, lazy_outcar, lazy_chgcar
 from vise.defaults import defaults
 
-warnings.simplefilter('ignore', UnknownPotcarWarning)
+def wrapped_make_parchg_dir(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import make_parchg_dir
+    return make_parchg_dir(args)
+
+def wrapped_make_refine_defect_poscar(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import make_refine_defect_poscar
+    return make_refine_defect_poscar(args)
+
+def wrapped_calc_charge_state(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import calc_charge_state
+    return calc_charge_state(args)
+
+def wrapped_make_defect_entry_main(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import make_defect_entry_main
+    return make_defect_entry_main(args)
+
+def wrapped_calc_grids(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import calc_grids
+    return calc_grids(args)
+
+def wrapped_make_defect_charge_info_main(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import make_defect_charge_info_main
+    return make_defect_charge_info_main(args)
+
+def wrapped_make_total_dos(args):
+    setup_warnings()
+    from pydefect.cli.vasp.main_vasp_util_functions import make_total_dos
+    return make_total_dos(args)
 
 
 def parse_args_main_vasp_util(args):
@@ -39,7 +65,7 @@ def parse_args_main_vasp_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['ccs'])
 
-    parser_calc_charge_state.set_defaults(func=calc_charge_state)
+    parser_calc_charge_state.set_defaults(func=wrapped_calc_charge_state)
 
     # -- make defect entry -----------------------------------------------------
     parser_make_defect_entry = subparsers.add_parser(
@@ -53,10 +79,10 @@ def parse_args_main_vasp_util(args):
         "-n", "--name", type=str, required=True,
         help="Name used for plotting energy diagram.")
     parser_make_defect_entry.add_argument(
-        "-p", "--perfect", type=Structure.from_file, required=True,
+        "-p", "--perfect", type=lazy_load_structure_mutable, required=True,
         help="Perfect supercell POSCAR file name.")
 
-    parser_make_defect_entry.set_defaults(func=make_defect_entry_main)
+    parser_make_defect_entry.set_defaults(func=wrapped_make_defect_entry_main)
 
     # -- make parchg dir -----------------------------------------------
     parser_make_parchg_dir = subparsers.add_parser(
@@ -70,7 +96,7 @@ def parse_args_main_vasp_util(args):
     parser_make_parchg_dir.add_argument(
         "-i", "--ibands", type=int, nargs="+",
         help="Band indices to be drawn, which start from 1.")
-    parser_make_parchg_dir.set_defaults(func=make_parchg_dir)
+    parser_make_parchg_dir.set_defaults(func=wrapped_make_parchg_dir)
 
     # -- make refine defect poscar ---------------------------------------------
     parser_make_refine_defect_poscar = subparsers.add_parser(
@@ -80,13 +106,13 @@ def parse_args_main_vasp_util(args):
         aliases=['rdp'])
 
     parser_make_refine_defect_poscar.add_argument(
-        "-p", "--poscar", dest="structure", type=Structure.from_file)
+        "-p", "--poscar", dest="structure", type=lazy_load_structure_mutable)
     parser_make_refine_defect_poscar.add_argument(
-        "-d", "--defect_entry", type=loadfn)
+        "-d", "--defect_entry", type=lazy_load_json)
     parser_make_refine_defect_poscar.add_argument(
         "-n", "--poscar_name", type=str)
     parser_make_refine_defect_poscar.set_defaults(
-        func=make_refine_defect_poscar)
+        func=wrapped_make_refine_defect_poscar)
 
     # -- calc grids ------------------------------------------------------------
     parser_calc_grids = subparsers.add_parser(
@@ -96,8 +122,8 @@ def parse_args_main_vasp_util(args):
         aliases=['cg'])
 
     parser_calc_grids.add_argument(
-        "-c", "--chgcar", type=Chgcar.from_file, required=True)
-    parser_calc_grids.set_defaults(func=calc_grids)
+        "-c", "--chgcar", type=lazy_chgcar, required=True)
+    parser_calc_grids.set_defaults(func=wrapped_calc_grids)
 
     # -- calc defect charge info -----------------------------------------------
     parser_calc_def_charge_info = subparsers.add_parser(
@@ -114,7 +140,7 @@ def parse_args_main_vasp_util(args):
     parser_calc_def_charge_info.add_argument(
         "-g", "--grids", type=Grids.from_file, required=True)
 
-    parser_calc_def_charge_info.set_defaults(func=make_defect_charge_info_main)
+    parser_calc_def_charge_info.set_defaults(func=wrapped_make_defect_charge_info_main)
 
     # -- make total dos for defect and carrier density -------------------------
     parser_make_total_dos = subparsers.add_parser(
@@ -123,12 +149,12 @@ def parse_args_main_vasp_util(args):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         aliases=['mtd'])
     parser_make_total_dos.add_argument(
-        "-v", "--vasprun", type=Vasprun, default=defaults.vasprun,
+        "-v", "--vasprun", type=lazy_vasprun, default=defaults.vasprun,
         help="vasprun.xml file name.")
     parser_make_total_dos.add_argument(
-        "-o", "--outcar", type=Outcar, default=defaults.outcar,
+        "-o", "--outcar", type=lazy_outcar, default=defaults.outcar,
         help="OUTCAR file name.")
-    parser_make_total_dos.set_defaults(func=make_total_dos)
+    parser_make_total_dos.set_defaults(func=wrapped_make_total_dos)
     # ----------------------------------------------------------------
     return parser.parse_args(args)
 


### PR DESCRIPTION
# Total Time Improvement (`--help`)

| call                               |   total_ms (Before) |   total_ms (After) |
|:-----------------------------------|-----------:|-----------:|
| import_pydefect_util_toplevel      |   4668.06  | 343.508 |
| import_pydefect_vasp_toplevel      |   4637.95  |  314.133 |
| import_pydefect_vasp_util_toplevel |   2544.39  |   2768.81  |
| import_pydefect_toplevel           |   1535.12  |   273.807 |
| import_pydefect_print_toplevel     |    365.838 |  261.717 |


# Before

| 各コマンド（＝ log ファイル名）
| に含まれる すべての import 行
| のうち 「self-time が 50 ms 以上」 のもの

| call                        | module                                                                 |   self_ms |
|:----------------------------|:-----------------------------------------------------------------------|----------:|
| pydefect_print_toplevel     | numpy.core.umath                                                       |    95.605 |
| pydefect_toplevel           | pymatgen.io.vasp.inputs                                                |   395.985 |
| pydefect_toplevel           | ase.io.formats                                                         |   187.97  |
| pydefect_toplevel           | scipy.special._ufuncs_cxx                                              |   100.288 |
| pydefect_toplevel           | scipy.special._ufuncs                                                  |    98.416 |
| pydefect_toplevel           | numpy.dtypes                                                           |    93.291 |
| pydefect_toplevel           | scipy.stats._stats_py                                                  |    56.142 |
| pydefect_toplevel           | scipy.stats._continuous_distns                                         |    50.72  |
| pydefect_util_toplevel      | pkg_resources                                                          |   517.563 |
| pydefect_util_toplevel      | pymatgen.analysis.bond_valence                                         |   448.101 |
| pydefect_util_toplevel      | pymatgen.io.vasp.inputs                                                |   392.638 |
| pydefect_util_toplevel      | emmet.core.utils                                                       |   284.24  |
| pydefect_util_toplevel      | networkx.utils.backends                                                |   214.899 |
| pydefect_util_toplevel      | ase.io.formats                                                         |   186.042 |
| pydefect_util_toplevel      | emmet.core.qchem.calc_types.enums                                      |   134.99  |
| pydefect_util_toplevel      | emmet.core.electronic_structure                                        |   118.506 |
| pydefect_util_toplevel      | numpy.core.umath                                                       |    96.217 |
| pydefect_util_toplevel      | scipy.linalg.lapack                                                    |    96.113 |
| pydefect_util_toplevel      | pymatgen.vis.structure_vtk                                             |    94.747 |
| pydefect_util_toplevel      | pymatgen.analysis.adsorption                                           |    92.245 |
| pydefect_util_toplevel      | matplotlib.patches                                                     |    79.21  |
| pydefect_util_toplevel      | pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies |    78.341 |
| pydefect_util_toplevel      | vtkmodules.vtkImagingCore                                              |    75.329 |
| pydefect_util_toplevel      | scipy.linalg._fblas                                                    |    75.213 |
| pydefect_util_toplevel      | pydantic_settings.main                                                 |    75.172 |
| pydefect_util_toplevel      | vtkmodules.vtkWebCore                                                  |    57.637 |
| pydefect_util_toplevel      | scipy.stats._stats_py                                                  |    55.541 |
| pydefect_vasp_toplevel      | pkg_resources                                                          |   493.611 |
| pydefect_vasp_toplevel      | pymatgen.analysis.bond_valence                                         |   438.339 |
| pydefect_vasp_toplevel      | pymatgen.io.vasp.inputs                                                |   392.711 |
| pydefect_vasp_toplevel      | emmet.core.utils                                                       |   282.382 |
| pydefect_vasp_toplevel      | networkx.utils.backends                                                |   215.575 |
| pydefect_vasp_toplevel      | ase.io.formats                                                         |   187.361 |
| pydefect_vasp_toplevel      | emmet.core.tasks                                                       |   144.687 |
| pydefect_vasp_toplevel      | emmet.core.qchem.calc_types.enums                                      |   136.883 |
| pydefect_vasp_toplevel      | numpy.core.numerictypes                                                |    95.98  |
| pydefect_vasp_toplevel      | pymatgen.analysis.adsorption                                           |    93.303 |
| pydefect_vasp_toplevel      | pymatgen.vis.structure_vtk                                             |    92.535 |
| pydefect_vasp_toplevel      | scipy.special._ufuncs_cxx                                              |    85.187 |
| pydefect_vasp_toplevel      | vtkmodules.vtkIOImage                                                  |    79.974 |
| pydefect_vasp_toplevel      | pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies |    79.389 |
| pydefect_vasp_toplevel      | scipy._lib._array_api                                                  |    79.179 |
| pydefect_vasp_toplevel      | pydantic_settings.main                                                 |    75.575 |
| pydefect_vasp_toplevel      | scipy.stats._continuous_distns                                         |    63.341 |
| pydefect_vasp_toplevel      | vtkmodules.vtkWebCore                                                  |    56.219 |
| pydefect_vasp_toplevel      | scipy.stats._stats_py                                                  |    55.54  |
| pydefect_vasp_util_toplevel | pymatgen.io.vasp.inputs                                                |   402.26  |
| pydefect_vasp_util_toplevel | ase.io.formats                                                         |   189.967 |
| pydefect_vasp_util_toplevel | scipy.linalg.lapack                                                    |   171.676 |
| pydefect_vasp_util_toplevel | numpy.core.umath                                                       |    95.206 |
| pydefect_vasp_util_toplevel | matplotlib.figure                                                      |    86.981 |
| pydefect_vasp_util_toplevel | scipy.stats._continuous_distns                                         |    58.677 |

# After

| call                        | module                         |   self_ms |
|:----------------------------|:-------------------------------|----------:|
| pydefect_print_toplevel     | numpy.compat                   |    95.402 |
| pydefect_toplevel           | numpy.core._multiarray_umath   |   102.512 |
| pydefect_util_toplevel      | numpy.core.umath               |    95.16  |
| pydefect_util_toplevel      | numpy.dtypes                   |    67.166 |
| pydefect_vasp_toplevel      | numpy.core._string_helpers     |    95.228 |
| pydefect_vasp_util_toplevel | pymatgen.io.vasp.inputs        |   387.51  |
| pydefect_vasp_util_toplevel | ase.io.formats                 |   176.481 |
| pydefect_vasp_util_toplevel | scipy.linalg._clapack          |    85.16  |
| pydefect_vasp_util_toplevel | math                           |    80.567 |
| pydefect_vasp_util_toplevel | scipy.stats._continuous_distns |    56.539 |
