### PR TITLE
magnetizationのエラーを無視するように変更

### DIFF
--- a/pydefect/analyzer/concentration/degeneracy.py
+++ b/pydefect/analyzer/concentration/degeneracy.py
@@ -89,7 +89,11 @@ class MakeDegeneracy:
     def mag_to_spin_degeneracy(self, mag: float) -> int:
         rounded_mag = round(mag)
         if abs(rounded_mag - mag) > self._int_threshold:
-            raise ValueError
+            # raise ValueError
+            Warning = (
+                f"Magnetization {mag} is not close to an integer. "
+                f"Rounded value is {rounded_mag}. "
+                "This may cause unexpected results.")
         return 2 * abs(rounded_mag) + 1
 
     @property


### PR DESCRIPTION
## 問題点
magnetizationの値が整数から離れすぎていて縮退度を正しく計算できないというエラーがpydefect_util make_degeneracies のところで出てしまう。
```
   INFO: Parsing data in ../defect/Ga_O1_5 ...
Traceback (most recent call last):
  File "/LARGE0/gr10261/nakajima/pydefect/pydefect/cli/main_tools.py", line 54, in parse_dirs
    _return = _inner_function(_dir)
  File "/LARGE0/gr10261/nakajima/pydefect/pydefect/cli/main_util_functions.py", line 107, in _inner
    make_deg.add_degeneracy(energy_info, calc_results, defect_str_info)
  File "/LARGE0/gr10261/nakajima/pydefect/pydefect/analyzer/concentration/degeneracy.py", line 84, in add_degeneracy
    spin = self.mag_to_spin_degeneracy(calc_results.magnetization)
  File "/LARGE0/gr10261/nakajima/pydefect/pydefect/analyzer/concentration/degeneracy.py", line 96, in mag_to_spin_degeneracy
    raise ValueError
None
ValueError
WARNING: Failing parsing ../defect/Ga_O1_5 ...
```

## 原因
実際にcalc_results.json を見るとmagnetizationが1.25となっており(1から0.25離れていて)、pydefectで指定されている閾値の0.1を超えて整数から離れていることが原因。
```
/LARGE0/gr10261/nakajima/research/pydecs_pydefect_compare/Ga2O3:Si/defect/Ga_O1_5
(std_python3.9) ➜  Ga_O1_5 pydefect_print calc_results.json
--------------------------------------------------------------------------------
file: calc_results.json
 -- calc results info
energy:  -1032.896
magnetization:   1.25
electronic convergence: True
ionic convergence: True
```

## 解決策
エラー判定を除く。

このエラー判定の役割は、計算で求めたスピン分極の誤差が一定値以上のものを除くことにあるらしい。
欠陥の濃度がexpで変化することを考慮するとスピン縮退度のこの程度の値の変化は濃度の値に大きく影響しないということが、このエラー判定を除いても大きな問題は無いと考えられる。