### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs_rst/vertical_transition_level.rst
+++ b/docs_rst/vertical_transition_level.rst
@@ -44,7 +44,7 @@ using the following command in the :code:`absorption/` directory.
     pydefect cr -d .
 
 
-And, wee obtain :code:`gkfo_correction.pdf` and :code:`gkfo_correction.json` files with the following command.
+And we obtain :code:`gkfo_correction.pdf` and :code:`gkfo_correction.json` files with the following command.
 
 ::
 


### PR DESCRIPTION
## Summary
- fix a small typo in `vertical_transition_level.rst`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: fixture 'mocker' not found and missing 'skimage')*

------
https://chatgpt.com/codex/tasks/task_e_684d32868d58832383dac5b269b464cc