### PR TITLE
Clarify random_3d_vector docstring

### DIFF
--- a/pydefect/input_maker/defect_entries_maker.py
+++ b/pydefect/input_maker/defect_entries_maker.py
@@ -124,7 +124,9 @@ def perturb_structure(structure: Structure, center: List[float], cutoff: float
 
 
 def random_3d_vector(max_distance: float) -> Tuple[np.ndarray, float]:
-    """Random 3d vector with uniform spherical distribution with 0 <= norm <= 1.
+    """Random 3d vector from a uniform spherical distribution.
+
+    Returns a random vector whose norm ranges from 0 up to ``max_distance``.
     stackoverflow.com/questions/5408276/python-uniform-spherical-distribution
     """
     phi = np.random.uniform(0, np.pi * 2)


### PR DESCRIPTION
## Summary
- describe that `random_3d_vector` returns vectors with norms up to `max_distance`

## Testing
- `pytest -q` *(fails: 12 failed, 275 passed, 4 skipped, 68 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d32b88504832392fa4941a267821d