### PR TITLE
Fix local variable name in print script

### DIFF
--- a/pydefect/cli/main_print_json.py
+++ b/pydefect/cli/main_print_json.py
@@ -8,16 +8,16 @@ from monty.serialization import loadfn
 def main():
     if sys.argv[1] == "repr":
         filenames = sys.argv[2:]
-        repr = True
+        use_repr = True
     else:
         filenames = sys.argv[1:]
-        repr = False
+        use_repr = False
 
     for filename in filenames:
         print("-"*80)
         print(f"file: {filename}")
         obj = loadfn(filename)
-        print(obj.__repr__()) if repr else print(obj.__str__())
+        print(obj.__repr__()) if use_repr else print(obj.__str__())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rename local variable `repr` to `use_repr` in `main_print_json.py`
- update variable references accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684d328eb4cc832384c1c54f9f8aaa2b